### PR TITLE
delete underbar if prefix is empty

### DIFF
--- a/src/main/java/org/embulk/input/marketo/MarketoUtils.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoUtils.java
@@ -83,7 +83,7 @@ public class MarketoUtils
 
     public static String buildColumnName(String prefix, String columnName)
     {
-        return prefix + "_" + columnName;
+        return prefix.isEmpty() ? columnName : prefix + "_" + columnName;
     }
 
     public static final List<DateRange> sliceRange(DateTime fromDate, DateTime toDate, int rangeSize)

--- a/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
@@ -56,6 +56,8 @@ public class MarketoUtilsTest
     {
         String columnName = MarketoUtils.buildColumnName("prefix", "columnName");
         assertEquals("prefix_columnName", columnName);
+        String noPrefixColumn = MarketoUtils.buildColumnName("", "columnName");
+        assertEquals("columnName", noPrefixColumn);
     }
 
     @Test


### PR DESCRIPTION
# Detail
* if `schema_column_prefix: ""`, deleted the prefix including underbar.
* if you don't specify schema_column_prefix, the column prefix is "mk_" in the same way as before.