### PR TITLE
add gem-push workflow

### DIFF
--- a/.github/workflow/gem-push.yml
+++ b/.github/workflow/gem-push.yml
@@ -1,0 +1,27 @@
+name: Ruby Gem
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: push gem
+        uses: trocco-io/push-gem-to-gpr-action@v1
+        with:
+          language: java
+          gem-path: "./build/gems/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "jacoco"
+    id "com.palantir.git-version" version "0.12.3"
 }
 import com.github.jrubygradle.JRubyExec
 repositories {
@@ -16,7 +17,15 @@ repositories {
 configurations {
     provided
 }
-version = "0.6.31"
+version = {
+    def baseVersion = "0.6.31"
+    def vd = versionDetails()
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9]+)?/) {
+        baseVersion
+    } else {
+        "${baseVersion}.${vd.gitHash}.pre"
+    }
+}()
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 


### PR DESCRIPTION
GemをGPRにpushするworkflowを追加します。
release作成時以外はcommit hashと`.pre` が追加される形になります。

利用するActionはこちら。
https://github.com/trocco-io/push-gem-to-gpr-action