### PR TITLE
use startsWith to determine the response is a text/csv or not

### DIFF
--- a/src/main/java/org/embulk/input/marketo/rest/MarketoInputStreamResponseEntityReader.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoInputStreamResponseEntityReader.java
@@ -48,7 +48,7 @@ public class MarketoInputStreamResponseEntityReader implements Jetty94ResponseRe
     @Override
     public InputStream readResponseContent() throws Exception
     {
-        if (!getResponse().getHeaders().getField(HttpHeader.CONTENT_TYPE).getValue().equals("text/csv")) {
+        if (!getResponse().getHeaders().getField(HttpHeader.CONTENT_TYPE).getValue().startsWith("text/csv")) {
             String errorString = readResponseContentInString();
 
             MarketoResponse<ObjectNode> errorResponse = OBJECT_READER.readValue(errorString);


### PR DESCRIPTION
# description

marketo rest api returns `Content-Type: text/csv;charset=UTF-8`
![image](https://github.com/trocco-io/embulk-input-marketo/assets/2437917/cec3f20f-6950-4d08-b095-52c36fdb18f6)